### PR TITLE
Bump whereabouts version to v0.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BCI_IMAGE} as bci
 
 FROM ${GO_IMAGE} as builder
 ARG ARCH="amd64"
-ARG TAG="v0.6.3"
+ARG TAG=v0.6.3
 ARG PKG="github.com/k8snetworkplumbingwg/whereabouts"
 ARG SRC="github.com/k8snetworkplumbingwg/whereabouts"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}


### PR DESCRIPTION



<Actions>
    <action id="b5b9bce7b37fb00152792fcab19be44292fd64369a4e7b3910b94c0e200fe6f8">
        <h3>Update whereabouts version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump to latest whereabouts version in Dockerfile</summary>
            <p>changed lines [7] of file &#34;/tmp/updatecli/github/rancher/image-build-whereabouts/Dockerfile&#34;</p>
            <details>
                <summary>v0.6.3</summary>
                <pre>&#xA;Release published on the 2024-01-08 15:18:57 +0000 UTC at the url https://github.com/k8snetworkplumbingwg/whereabouts/releases/tag/v0.6.3&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* Add overlapping ranges check to network_name feature by @andreaskaris in https://github.com/k8snetworkplumbingwg/whereabouts/pull/355&#xD;&#xA;* Improve AssignmentError message by @andreaskaris in https://github.com/k8snetworkplumbingwg/whereabouts/pull/366&#xD;&#xA;* IterateForAssignment: Properly handle invalid syntax for exclude range by @andreaskaris in https://github.com/k8snetworkplumbingwg/whereabouts/pull/365&#xD;&#xA;* Denormalize IP name before checking if pod is alive by @nicklesimba in https://github.com/k8snetworkplumbingwg/whereabouts/pull/360&#xD;&#xA;* Rechecking pending Pods (conflict resolved) by @nicklesimba in https://github.com/k8snetworkplumbingwg/whereabouts/pull/375&#xD;&#xA;* update golang.org/x/net to v0.17.0 by @zshi-redhat in https://github.com/k8snetworkplumbingwg/whereabouts/pull/390&#xD;&#xA;* Configurable cron schedule for reconciler by @maiqueb in https://github.com/k8snetworkplumbingwg/whereabouts/pull/398&#xD;&#xA;* Corrects name for configmap in extended config docs by @dougbtv in https://github.com/k8snetworkplumbingwg/whereabouts/pull/402&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @zshi-redhat made their first contribution in https://github.com/k8snetworkplumbingwg/whereabouts/pull/390&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k8snetworkplumbingwg/whereabouts/compare/v0.6.2...v0.6.3</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

