### PR TITLE
Use BCI busybox instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base
+ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
 ARG GO_IMAGE=rancher/hardened-build-base:v1.20.12b2
 FROM ${BCI_IMAGE} as bci
 


### PR DESCRIPTION
Moving to a smaller base image. We can't use `scratch` because we execute a bash script