### PR TITLE
Use cross-compilation and remove all references to ARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,18 @@ ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
 ARG GO_IMAGE=rancher/hardened-build-base:v1.21.10b1
 FROM ${BCI_IMAGE} as bci
 
-FROM ${GO_IMAGE} as builder
-ARG ARCH="amd64"
+# Image that provides cross compilation tooling.
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.3.0 AS xx
+
+FROM --platform=$BUILDPLATFORM ${GO_IMAGE} as base-builder
+# copy xx scripts to your build stage
+COPY --from=xx / /
+RUN apk add file make git clang lld 
+ARG TARGETPLATFORM
+RUN set -x && \
+    xx-apk --no-cache add musl-dev gcc 
+
+FROM base-builder as whereabouts-builder
 ARG TAG=v0.7.0
 ARG PKG="github.com/k8snetworkplumbingwg/whereabouts"
 ARG SRC="github.com/k8snetworkplumbingwg/whereabouts"
@@ -11,6 +21,9 @@ RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
+RUN go mod download
+# cross-compilation setup
+ARG TARGETARCH
 
 ENV GO111MODULE=on
 RUN GIT_SHA=$(git rev-parse --short HEAD) \
@@ -18,15 +31,22 @@ RUN GIT_SHA=$(git rev-parse --short HEAD) \
     export GO_LDFLAGS="-X ${PKG}/pkg/version.Version=${TAG} \
     -X ${PKG}/pkg/version.GitSHA=${GIT_SHA} \
     -X ${PKG}/pkg/version.GitTreeState=${GIT_TREE_STATE}" && \
+    xx-go --wrap && \
     go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -mod vendor -o bin/whereabouts cmd/whereabouts.go && \
     go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -mod vendor -o bin/ip-control-loop cmd/controlloop/*.go
 RUN go-assert-boring.sh bin/*
-RUN install -s bin/* /usr/local/bin
-RUN whereabouts --version
+RUN xx-verify --static bin/*
+RUN install bin/* /usr/local/bin
+
+FROM ${GO_IMAGE} as strip_binary
+#strip needs to run on TARGETPLATFORM, not BUILDPLATFORM
+COPY --from=whereabouts-builder /usr/local/bin/whereabouts   .
+COPY --from=whereabouts-builder /usr/local/bin/ip-control-loop .
+RUN strip ./whereabouts ./ip-control-loop
 
 FROM bci
-COPY --from=builder /usr/local/bin/whereabouts   .
-COPY --from=builder /usr/local/bin/ip-control-loop .
+COPY --from=strip_binary /go/whereabouts .
+COPY --from=strip_binary /go/ip-control-loop .
 ARG PKG="github.com/k8snetworkplumbingwg/whereabouts"
-COPY --from=builder /go/src/${PKG}/script/install-cni.sh .
+COPY --from=whereabouts-builder /go/src/${PKG}/script/install-cni.sh .
 CMD ["/install-cni.sh"]

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ image-build:
 	docker buildx build \
 		--platform=$(ARCH) \
 		--pull \
-		--build-arg ARCH=$(ARCH) \
 		--build-arg PKG=$(PKG) \
 		--build-arg SRC=$(SRC) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \


### PR DESCRIPTION
Use cross-compilation to optimize build-time

Also remove all references to ARCH to make sure we build for TARGETARCH

See https://docs.docker.com/build/guide/multi-platform/#platform-build-arguments