### PR TITLE
Bump go version to fix GO-2024-3106

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
-ARG GO_IMAGE=rancher/hardened-build-base:v1.21.11b3
+ARG GO_IMAGE=rancher/hardened-build-base:v1.22.7b1
 FROM ${BCI_IMAGE} AS bci
 
 # Image that provides cross compilation tooling.


### PR DESCRIPTION
Bump hardened-build-base to versions that use 1.22.7 which contains the fix for the CVE