### PR TITLE
Bump build base version to v1.23.10b1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
-ARG GO_IMAGE=rancher/hardened-build-base:v1.23.8b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.23.10b1
 FROM ${BCI_IMAGE} AS bci
 
 # Image that provides cross compilation tooling.


### PR DESCRIPTION
Resolve the following stdlib CVEs:
- CVE-2025-4673
- CVE-2025-0913
- CVE-2025-22874