### PR TITLE
Fix golang.org/x/net and golang.org/x/sys CVEs via go.mod override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
 RUN go mod download
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 # cross-compilation setup
 ARG TARGETARCH
 

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,6 @@
+# golang.org/x/net: CVE-2026-25681, CVE-2026-27136 (net/html XSS), CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode), CVE-2026-25680, CVE-2026-42502, CVE-2026-42506 (net/html XSS/DoS).
+# Drop once upstream requires golang.org/x/net >= v0.55.0.
+-replace golang.org/x/net=golang.org/x/net@v0.55.0
+# golang.org/x/sys: CVE-2026-39824 (integer overflow in NewNTUnicodeString in golang.org/x/sys/windows).
+# Drop once upstream requires golang.org/x/sys >= v0.44.0.
+-replace golang.org/x/sys=golang.org/x/sys@v0.44.0


### PR DESCRIPTION
## Problem

The `hardened-whereabouts` image ships HIGH/MEDIUM `golang.org/x/net` and `golang.org/x/sys` CVEs that are not yet fixed in the pinned upstream release (`v0.9.4`). From a `trivy image --vex repo rancher/hardened-whereabouts:v0.9.4-build20260709` scan (8 findings in each of `whereabouts`, `ip-control-loop`, `ip-reconciler`, `node-slice-controller`):

- **`golang.org/x/net` v0.49.0 → v0.55.0**
  - CVE-2026-25681 (HIGH) — `net/html`: arbitrary code execution via XSS
  - CVE-2026-27136 (HIGH) — `net/html`: XSS via HTML parsing bypass
  - CVE-2026-33814 (HIGH) — `net/http2`: DoS via malformed `SETTINGS_MAX_FRAME_SIZE` frame
  - CVE-2026-39821 (HIGH) — `net/idna`: privilege escalation via incorrect Punycode label processing
  - CVE-2026-25680 (MEDIUM) — `net/html`: DoS via excessive HTML parsing
  - CVE-2026-42502 (MEDIUM) — `net/html`: XSS via unexpected HTML tree rendering
  - CVE-2026-42506 (MEDIUM) — `net/html`: XSS via arbitrary HTML parsing
- **`golang.org/x/sys` v0.40.0 → v0.44.0**
  - CVE-2026-39824 — integer overflow in `NewNTUnicodeString` in `golang.org/x/sys/windows`

## Fix

Use the shared, declarative go.mod override mechanism (`go-mod-overrides.sh` from `rancher/hardened-build-base`), following the pattern in rancher/image-build-cluster-proportional-autoscaler#133:

- Add a repo-root **`go-mod-overrides`** file pinning `golang.org/x/net` to `v0.55.0` and `golang.org/x/sys` to `v0.44.0`. Each entry references the CVE(s) so it can be dropped once upstream catches up.
- Wire the `whereabouts-builder` stage in the Dockerfile to run `go-mod-overrides.sh` after `go mod download` and before the binaries are built.

## Note

`go-mod-overrides.sh` is provided by the `hardened-build-base` base image. Ensure the pinned `GO_IMAGE` ships the script; if the build can't find it, bump `GO_IMAGE` to a `hardened-build-base` release that includes it.

CVE source: rke2-toolbox scan report for `rancher/hardened-whereabouts:v0.9.4-build20260709`.