### PR TITLE
Override golang.org/x/net@v0.56.0 and golang.org/x/text@v0.39.0 to fix CVEs

### DIFF
--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,6 +1,9 @@
-# golang.org/x/net: CVE-2026-25681, CVE-2026-27136 (net/html XSS), CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode), CVE-2026-25680, CVE-2026-42502, CVE-2026-42506 (net/html XSS/DoS).
-# Drop once upstream requires golang.org/x/net >= v0.55.0.
--replace golang.org/x/net=golang.org/x/net@v0.55.0
+# golang.org/x/net: CVE-2026-25681, CVE-2026-27136 (net/html XSS), CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode), CVE-2026-25680, CVE-2026-42502, CVE-2026-42506 (net/html XSS/DoS), CVE-2026-46600 (x/net/dns/dnsmessage panic parsing invalid SVCB or HTTPS RR).
+# Drop once upstream requires golang.org/x/net >= v0.56.0.
+-replace golang.org/x/net=golang.org/x/net@v0.56.0
 # golang.org/x/sys: CVE-2026-39824 (integer overflow in NewNTUnicodeString in golang.org/x/sys/windows).
 # Drop once upstream requires golang.org/x/sys >= v0.44.0.
 -replace golang.org/x/sys=golang.org/x/sys@v0.44.0
+# golang.org/x/text: CVE-2026-56852 (infinite loop on invalid input).
+# Drop once upstream requires golang.org/x/text >= v0.39.0.
+-replace golang.org/x/text=golang.org/x/text@v0.39.0


### PR DESCRIPTION
## What this does

Updates `go-mod-overrides` to resolve vulnerabilities reported by Trivy against `rancher/hardened-whereabouts:v0.9.4-build20260710` (found across the `ip-control-loop`, `ip-reconciler`, `node-slice-controller`, and `whereabouts` binaries):

| Library | Vulnerability | Installed | Fixed |
| --- | --- | --- | --- |
| `golang.org/x/net` | CVE-2026-46600 — parsing an invalid SVCB or HTTPS RR can panic in `golang.org/x/net/dns/dnsmessage` | v0.55.0 | v0.56.0 |
| `golang.org/x/text` | CVE-2026-56852 — infinite loop on invalid input in `golang.org/x/text` | v0.37.0 | v0.39.0 |

### Changes
- Bump the existing `golang.org/x/net` override from `v0.55.0` to `v0.56.0` (and note CVE-2026-46600 in the comment).
- Add a new `golang.org/x/text` override at `v0.39.0`.

The existing `golang.org/x/sys` override (v0.44.0) is unchanged — it was not flagged by this scan.

These overrides can be dropped once upstream requires `golang.org/x/net >= v0.56.0` and `golang.org/x/text >= v0.39.0`.

> Note: the scan also flags a SLES OS package finding (`glibc` SUSE-SU-2026:3030-1). That is resolved by a base-image rebuild with updated packages, not via `go-mod-overrides`.

Follows the same approach as rancher/image-build-dns-nodecache#188.